### PR TITLE
issue #8 fix: added Enet4's print_to_file code for javascript

### DIFF
--- a/perf.js
+++ b/perf.js
@@ -1,3 +1,5 @@
+const fs = require('fs'); // for print to file benchmark
+
 (function () {
     'use strict';
 
@@ -42,7 +44,6 @@
 
     // print to file
 
-    const fs = require('fs');
     function printfd(n) {
 	let f = fs.openSync("/dev/null", "w");
 	for (let i = 1; i <= n; i++) {

--- a/perf.js
+++ b/perf.js
@@ -39,18 +39,26 @@
     }
     console.log("javascript,parse_integers," + tmin/100);
 
-    //    for (i=0; i < 5; i++) {
-    //        t = (new Date()).getTime();	
-    //	filename = "/dev/null";
-    //	fd : StreamWriter = new StreamWriter(filepathIncludingFileName);
-    //    	  for (j=0; j < 100000; j++) {
-    //            s = j.toString();
-    //            fd.WriteLine(s + " " + s);
-    //        }
-    //        t = (new Date()).getTime()-t;
-    //        if (t < tmin) { tmin = t; }
-    //    }
-    //   console.log("javascript,print_to_file," + 9999);
+
+    // print to file
+
+    const fs = require('fs');
+    function printfd(n) {
+	let f = fs.openSync("/dev/null", "w");
+	for (let i = 1; i <= n; i++) {
+	    fs.writeSync(f, `${i} ${i + 1}\n`);
+	}
+	fs.closeSync(f);
+    }
+  
+    tmin = Number.POSITIVE_INFINITY;
+    for (i=0; i < 5; i++) {
+        t = (new Date()).getTime();
+	printfd(100000)
+	t = (new Date()).getTime()-t;
+	if (t < tmin) { tmin = t; }
+    }
+    console.log("javascript,print_to_file," + tmin);
 
     // mandelbrot set //
 


### PR DESCRIPTION
Fix for [#8](https://github.com/JuliaLang/Microbenchmarks/issues/8). Add `print_to_file` function for javascript, which removes the need to deal with missing data in the benchmarks. 