### PR TITLE
recursion_fibonacci updated to be Mathematica like

### DIFF
--- a/perf.nb
+++ b/perf.nb
@@ -38,9 +38,12 @@ On[Assert];
 (* recursive fib *)
 
 ClearAll[fib];
-fib = Compile[{{n, _Integer}},
-	If[n < 2, n, fib[n - 1] + fib[n - 2]],
-	CompilationTarget -> "WVM"
+fib[nn_] := Module[{recFib},
+  Clear[recFib];
+  recFib[n_] := recFib[n] = recFib[n - 1] + recFib[n - 2];
+  recFib[0] = 0;
+  recFib[1] = 1;
+  recFib[nn]
 ];
 
 test[fib[20] == 6765];


### PR DESCRIPTION
Previous implementation of 'recursion_fibonacci' method was C code in Mathematica. Changed it to Mathematica-like implementation wrapped in Module[] to avoid cashing. On my Macbook pro the improvement is 42 times... 

It is even faster if Module[] isolation is not used, but Mathematica does caching of previous results thus it would be not a fair comparison. Read more on: http://community.wolfram.com/groups/-/m/t/442573