### PR TITLE
parseint: move m==n assertions inside loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ endif
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
 
-NODEJSBIN = nodejs
+NODEJSBIN = node8
 
 #Use python2 for Python 2.x
 PYTHON = python3
+
+OCTAVE = octave-cli
 
 ifeq ($(OS), WINNT)
 MATHEMATICABIN = MathKernel
@@ -102,7 +104,7 @@ benchmarks/matlab.csv: perf.m
 	for t in 1 2 3 4 5; do matlab -nojvm -singleCompThread -r 'perf; perf; exit' | grep ^matlab | tail -8; done >$@
 
 benchmarks/octave.csv: perf.m
-	for t in 1 2 3 4 5; do octave -q --eval perf 2>/dev/null; done >$@
+	for t in 1 2 3 4 5; do $(OCTAVE) -q --eval perf 2>/dev/null; done >$@
 
 benchmarks/r.csv: perf.R
 	for t in 1 2 3 4 5; do cat $< | R --vanilla --slave 2>/dev/null; done >$@
@@ -132,7 +134,7 @@ LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave pyt
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson
-#	scala
+#	scala, stata
 
 BENCHMARKS = $(foreach lang,$(LANGUAGES),benchmarks/$(lang).csv)
 

--- a/bin/table.jl
+++ b/bin/table.jl
@@ -3,6 +3,8 @@
 # This script generates the table published at https://julialang.org/benchmarks/
 # (file _includes/benchmarks.html in the JuliaLang/julialang.github.com repository)
 
+using Statistics
+
 const benchmark_order = [
     "iteration_pi_sum",
     "recursion_fibonacci",

--- a/perf.R
+++ b/perf.R
@@ -46,7 +46,7 @@ printfdperf = function(t) {
     for (i in 1:t) {
         s = sprintf("%d %d", i, i+1)
 	writeLines(s, fd)
-    }	
+    }
 }
 
 timeit("print_to_file", printfdperf, 100000)

--- a/perf.jl
+++ b/perf.jl
@@ -4,7 +4,6 @@ using LinearAlgebra
 using Test
 using Printf
 
-
 include("./perfutil.jl")
 
 ## recursive fib ##
@@ -22,8 +21,8 @@ function parseintperf(t)
         n = rand(UInt32)
         s = string(n, base = 16)
         m = UInt32(parse(Int64,s, base = 16))
+        @assert m == n
     end
-    @test m == n
     return n
 end
 

--- a/perf.js
+++ b/perf.js
@@ -51,7 +51,7 @@ const fs = require('fs'); // for print to file benchmark
 	}
 	fs.closeSync(f);
     }
-  
+
     tmin = Number.POSITIVE_INFINITY;
     for (i=0; i < 5; i++) {
         t = (new Date()).getTime();

--- a/perf.lua
+++ b/perf.lua
@@ -36,7 +36,7 @@ local function timeit(f, name, check)
         k = k + 1
         local tx, val1, val2 = elapsed(f)
         t = min(t, tx)
-        if check then 
+        if check then
             check(val1, val2)
         end
         if k > 5 and (nowutc() - s):toseconds() >= 2 then break end
@@ -62,8 +62,8 @@ local function parseint()
         n = random(lmt) -- Between 0 and 2^32 - 1, i.e. uint32_t.
         local s = format('0x%x', tonumber(n))
         m = tonumber(s)
+        assert(n == m) -- Done here to be even with Julia benchmark.
     end
-    assert(n == m) -- Done here to be even with Julia benchmark.
     return n, m
 end
 
@@ -142,13 +142,13 @@ local function pisum()
     return s
 end
 
-timeit(pisum, 'iteration_pi_sum', function(x) 
+timeit(pisum, 'iteration_pi_sum', function(x)
     assert(abs(x - 1.644834071848065) < 1e-12)
 end)
 
 local function rand(r, c)
     local x = mat(r, c)
-    for i=1,#x do 
+    for i=1,#x do
         x[i] = rng:sample()
     end
     return x
@@ -156,8 +156,8 @@ end
 
 local function randn(r, c)
     local x = mat(r, c)
-    for i=1,#x do 
-        x[i] = dist.normal(0, 1):sample(rng) 
+    for i=1,#x do
+        x[i] = dist.normal(0, 1):sample(rng)
     end
     return x
 end
@@ -175,7 +175,7 @@ local function randmatstat(t)
     return sqrt(var(v))/mean(v), sqrt(var(w))/mean(w)
 end
 
-timeit(function() return randmatstat(1000) end, 'matrix_statistics', 
+timeit(function() return randmatstat(1000) end, 'matrix_statistics',
     function(s1, s2)
         assert( 0.5 < s1 and s1 < 1.0 and 0.5 < s2 and s2 < 1.0 )
     end)

--- a/perf.m
+++ b/perf.m
@@ -6,43 +6,43 @@
 function perf()
 
 	warning off;
-	
+
 	f = fib(20);
 	assert(f == 6765)
 	timeit('recursion_fibonacci', @fib, 20)
-	
+
 	timeit('parse_integers', @parseintperf, 1000)
-	
+
 	%% array constructors %%
 
 	%o = ones(200,200);
 	%assert(all(o) == 1)
 	%timeit('ones', @ones, 200, 200)
-	
+
 	%assert(all(matmul(o) == 200))
 	%timeit('AtA', @matmul, o)
-	
+
 	mandel(complex(-.53,.68));
 	assert(sum(sum(mandelperf(true))) == 14791)
 	timeit('userfunc_mandelbrot', @mandelperf, true)
-	
+
 	assert(issorted(sortperf(5000)))
 	timeit('recursion_quicksort', @sortperf, 5000)
-	
+
 	s = pisum(true);
 	assert(abs(s-1.644834071848065) < 1e-12);
 	timeit('iteration_pi_sum',@pisum, true)
-	
+
 	%s = pisumvec(true);
 	%assert(abs(s-1.644834071848065) < 1e-12);
 	%timeit('pi_sum_vec',@pisumvec, true)
-	
+
 	[s1, s2] = randmatstat(1000);
 	assert(round(10*s1) > 5 && round(10*s1) < 10);
 	timeit('matrix_statistics', @randmatstat, 1000)
-	
+
 	timeit('matrix_multiply', @randmatmul, 1000);
-	
+
 	printfd(1)
 	timeit('print_to_file', @printfd, 100000)
 
@@ -126,7 +126,7 @@ function M = mandelperf(ignore)
     x=-2.0:.1:0.5;
     y=-1:.1:1;
     M=zeros(length(y),length(x));
-    for r=1:size(M,1) 
+    for r=1:size(M,1)
         for c=1:size(M,2)
            M(r,c) = mandel(x(c)+y(r)*i);
         end

--- a/perf.nb
+++ b/perf.nb
@@ -55,10 +55,10 @@ parseintperf[t_] := Module[
 		n = RandomInteger[{0, 4294967295}];
 		s = IntegerString[n, 16];
 		m = FromDigits[s, 16];
+		test[ m == n];
 		,
 		{i, 1, t}
 	];
-	test[ m == n];
 	n
 ];
 

--- a/perfutil.jl
+++ b/perfutil.jl
@@ -1,6 +1,6 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-using Printf, Random
+using Printf, Random, Statistics
 
 const mintrials = 5
 const mintime = 2000.0

--- a/scala/src/main/scala/perf.scala
+++ b/scala/src/main/scala/perf.scala
@@ -52,9 +52,9 @@ object PerfBreeze {
         rand = generator.nextInt()
         rands = if(rand < 0) "-" + abs(rand).toHexString else rand.toHexString
         parsed = Integer.parseInt(rands, 16)
+        assert(rand == parsed)
       }
       val t = System.nanoTime() - t1
-      assert(rand == parsed)
       if(t < tmin) tmin = t
     }
     tmin / 1000.0


### PR DESCRIPTION
standardizes location of m==n assertion in parseint loop, as noted in Issue #4, plus

- track deprecations of statistics functions in Julia base
- some small build tweaks for changes in language packages under opensuse 42.3 -> 15.0  
- removal of trailing whitespace in perf.*