### PR TITLE
More efficient random numbers for Octave parse_integer (issue #4)

### DIFF
--- a/perf.m
+++ b/perf.m
@@ -91,7 +91,7 @@ end
 
 function n = parseintperf(t)
     for i = 1:t
-        n = randi([0,2^32-1],1,'uint32');
+        n = fix(rand*(2^32));
         s = sprintf('%08x',n);
         m = sscanf(s,'%x');
         assert(m == n);


### PR DESCRIPTION
Switch to a more efficient random int generator for Octave parse_integer. Gives factor of 4 improvement. 