### PR TITLE
add @compat calls for 0.6/0.7/1.0 compatibility

### DIFF
--- a/bin/table.jl
+++ b/bin/table.jl
@@ -3,7 +3,9 @@
 # This script generates the table published at https://julialang.org/benchmarks/
 # (file _includes/benchmarks.html in the JuliaLang/julialang.github.com repository)
 
-using Statistics
+using Compat
+import Compat.Statistics
+import Compat.Printf
 
 const benchmark_order = [
     "iteration_pi_sum",
@@ -53,10 +55,10 @@ function lang_by(lang::String)
     # C is placed at the start of the list
     lang == "c" ? -Inf :
     # Julia is sorted immediately after C
-    lang == "julia" ? -realmax() :
+    @compat lang == "julia" ? -floatmax() :
     # The rest of the languages are sorted by the geometric mean of their benchmark values
     # See https://en.wikipedia.org/wiki/Geometric_mean#Relationship_with_logarithms for details
-    exp(mean(log.(collect(values(benchmarks[lang])))))
+    @compat exp(Statistics.mean(log.(collect(values(benchmarks[lang])))))
 end
 
 const language_order = sort!(collect(keys(benchmarks)), by=lang_by)
@@ -94,15 +96,13 @@ print("""
     <tbody>
 """)
 
-using Printf
-
 for benchmark in benchmark_order
     println("        <tr><th>$benchmark</th>")
     c_time = benchmarks["c"][benchmark]
     for lang in language_order
         rel_time = "n/a"
         if haskey(benchmarks[lang], benchmark)
-            rel_time = @sprintf "%.2f" benchmarks[lang][benchmark]/c_time
+            @compat rel_time = Printf.@sprintf "%.2f" benchmarks[lang][benchmark]/c_time
         end
         println("            <td class=\"data\">$rel_time</td>")
     end

--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -13,7 +13,7 @@ echo -n java,
 java -version 2>&1 |grep "version" | cut -f3 -d " " | cut -c 2-9
 
 echo -n "javascript,V8 "
-nodejs -e "console.log(process.versions.v8)"
+node8 -e "console.log(process.versions.v8)"
 
 echo -n "julia,"
 $JULIAHOME/usr/bin/julia -v | cut -f3 -d" "
@@ -29,7 +29,7 @@ echo -n "matlab,R"
 matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n3 | head -n1 | cut -f5 -d" " | sed "s/'//g"
 
 echo -n "octave,"
-octave -v | grep version | cut -f4 -d" "
+octave-cli -v | grep version | cut -f4 -d" "
 
 echo -n "python,"
 python3 -V 2>&1 | cut -f2 -d" "


### PR DESCRIPTION
Microbenchmark codes now run on 0.6, 0.7 and 1.0. This is useful for comparing performance across versions. 

Also some updates to names of languages in versions.sh (octave -> octave-cli, etc.) 

Some of my Compat.jl calls are a little funky (e.g. an ifdef-style switch for tr/trace) because the expected syntax did not work. 