### PR TITLE
Improve Fortran parse_int benchmark

### DIFF
--- a/perf.f90
+++ b/perf.f90
@@ -13,7 +13,7 @@ use types, only: dp, i64
 implicit none
 private
 public trace, mean, std, init_random_seed, randn, assert, stop_error, &
-     sysclock2ms
+     sysclock2ms, hex_string
 
 contains
 
@@ -142,6 +142,44 @@ function sysclock2ms(t)
   r = 1000._dp / rate
   sysclock2ms = t * r
 end function sysclock2ms
+
+! Convert an integer to a hex string
+!
+subroutine hex_string(dec,hexchar)
+  integer, intent(in) :: dec
+  character(*) :: hexchar
+  character(len(hexchar)) :: tempchar
+
+  integer :: i
+  integer :: quotient, remainder
+
+  character(len=1), parameter :: table(0:16) = &
+  [(char(i),i=48,57),(char(i),i=65,71)]
+
+  quotient = dec
+  
+  hexchar(:) = ' '
+  tempchar(:) = ' '
+
+  i = 1
+  do while (quotient /= 0 .and. i <= len(hexchar))
+
+      remainder = modulo(quotient,16)
+
+      tempchar(i:i) = table(remainder)
+      i = i+1
+
+      quotient = quotient/16
+
+  end do
+
+  do i=1,len_trim(tempchar)
+
+      hexchar(i:i) = tempchar(len_trim(tempchar)-i+1:len_trim(tempchar)-i+1)
+
+  end do
+
+end subroutine hex_string
 
 end module
 
@@ -324,7 +362,7 @@ end module
 
 program perf
 use types, only: dp, i64
-use utils, only: assert, init_random_seed, sysclock2ms
+use utils, only: assert, init_random_seed, sysclock2ms, hex_string
 use bench, only: fib, parse_int, printfd, quicksort, mandelperf, pisum, randmatstat, &
     randmatmul
 implicit none
@@ -357,7 +395,7 @@ do i = 1, 5
         do k = 1, 1000
             call random_number(s1)
             n = int(s1*huge(n))
-            write(s, '(z0)') n
+            call hex_string(n,s)
             m = parse_int(s(:len_trim(s)), 16)
             call assert(m == n)
         end do

--- a/perf.f90
+++ b/perf.f90
@@ -153,8 +153,8 @@ subroutine hex_string(dec,hexchar)
   integer :: i
   integer :: quotient, remainder
 
-  character(len=1), parameter :: table(0:16) = &
-  [(char(i),i=ichar('0'),ichar('9')),(char(i),i=ichar('A'),ichar('G'))]
+  character(len=1), parameter :: table(0:15) = &
+  [(char(i),i=ichar('0'),ichar('9')),(char(i),i=ichar('A'),ichar('F'))]
 
   quotient = dec
   

--- a/perf.f90
+++ b/perf.f90
@@ -207,23 +207,21 @@ integer function parse_int(s, base) result(n)
 character(len=*), intent(in) :: s
 integer, intent(in) :: base
 integer :: i, d
-
-integer, parameter :: table(0:127) = [integer::&
-[(-1,i=1,48)], &  
-[(i,i=0,9)], &     ! 0-9
-[(-1,i=1,7)], &
-[(10+i,i=0,25)], & ! A-Z
-[(-1,i=1,7)], &
-[(10+i,i=0,25)], & ! a-z
-[(-1,i=1,4)] &
-]
-
+character :: c
 n = 0
 do i = 1, len(s)
-    
-    d = table(iachar(s(i:i)))
+    c = s(i:i)
+    d = 0
+    if (ichar(c) >= ichar('0') .and. ichar(c) <= ichar('9')) then
+        d = ichar(c) - ichar('0')
+    else if (ichar(c) >= ichar('A') .and. ichar(c) <= ichar('Z')) then
+        d = ichar(c) - ichar('A') + 10
+    else if (ichar(c) >= ichar('a') .and. ichar(c) <= ichar('z')) then
+        d = ichar(c) - ichar('a') + 10
+    else
+        call stop_error("parse_int 1")
+    end if
 
-    if (d < 0 ) call stop_error("bench:parse_int - Illegal character in input")
     if (base <= d) call stop_error("parse_int 2")
     n = n*base + d
 end do

--- a/perf.f90
+++ b/perf.f90
@@ -207,21 +207,23 @@ integer function parse_int(s, base) result(n)
 character(len=*), intent(in) :: s
 integer, intent(in) :: base
 integer :: i, d
-character :: c
+
+integer, parameter :: table(0:127) = [integer::&
+[(-1,i=1,48)], &  
+[(i,i=0,9)], &     ! 0-9
+[(-1,i=1,7)], &
+[(10+i,i=0,25)], & ! A-Z
+[(-1,i=1,7)], &
+[(10+i,i=0,25)], & ! a-z
+[(-1,i=1,4)] &
+]
+
 n = 0
 do i = 1, len(s)
-    c = s(i:i)
-    d = 0
-    if (ichar(c) >= ichar('0') .and. ichar(c) <= ichar('9')) then
-        d = ichar(c) - ichar('0')
-    else if (ichar(c) >= ichar('A') .and. ichar(c) <= ichar('Z')) then
-        d = ichar(c) - ichar('A') + 10
-    else if (ichar(c) >= ichar('a') .and. ichar(c) <= ichar('z')) then
-        d = ichar(c) - ichar('a') + 10
-    else
-        call stop_error("parse_int 1")
-    end if
+    
+    d = table(iachar(s(i:i)))
 
+    if (d < 0 ) call stop_error("bench:parse_int - Illegal character in input")
     if (base <= d) call stop_error("parse_int 2")
     n = n*base + d
 end do

--- a/perf.f90
+++ b/perf.f90
@@ -154,7 +154,7 @@ subroutine hex_string(dec,hexchar)
   integer :: quotient, remainder
 
   character(len=1), parameter :: table(0:16) = &
-  [(char(i),i=48,57),(char(i),i=65,71)]
+  [(char(i),i=ichar('0'),ichar('9')),(char(i),i=ichar('A'),ichar('G'))]
 
   quotient = dec
   


### PR DESCRIPTION
The poor performance of the Fortran `parse_int` benchmark is attributable to the use of an inefficient _internal write_ statement to generate the hex string for parsing, _i.e._ you are mostly benchmarking the `write` statement currently.
While functional the internal write statement is not a suitable choice for this task; I have instead added a specific routine for generating the hex string, as done in some of the other language benchmarks, which on my machine takes almost 70% off the benchmark time for `-O3`.
I have also replaced the branching logic in the `parse_int` with a static table which is more representative of how this kind of character parsing is performed.