### PR TITLE
improve `fib()` in R

### DIFF
--- a/perf.R
+++ b/perf.R
@@ -17,11 +17,12 @@ timeit = function(name, f, ..., times=5) {
 ## fib ##
 
 fib = function(n) {
-    if (n < 2) {
-        return(n)
-    } else {
-        return(fib(n-1) + fib(n-2))
-    }
+    if (n < 2) return(n)
+    if (n == 2) return(1)
+    k = integer(n)
+    k[1:2] = c(1L, 1L)
+    for (i in 3:n) k[i] = k[i - 1] + k[i - 2]
+    return(k[n])
 }
 
 assert(fib(20) == 6765)


### PR DESCRIPTION
I propose to improve the `fib()` function in R using vector preallocation. This is standard practice in R, and speeds up by more than 500 times compared to the current version. 

```r
library("microbenchmark")

fib_new = function(n) {
  if (n < 2) return(n)
  if (n == 2) return(1)
  k = integer(n)
  k[1:2] = c(1L, 1L)
  for (i in 3:n) k[i] = k[i - 1] + k[i - 2]
  return(k[n])
}

# current version
fib = function(n) {
  if (n < 2) {
    return(n)
  } else {
    return(fib(n-1) + fib(n-2))
  }
}

microbenchmark(fib_new(20), fib(20), check = "equal")
#> Unit: microseconds
#>         expr       min        lq       mean     median         uq       max
#>  fib_new(20)    87.032    90.727   113.2529   108.7905   132.8065   173.654
#>      fib(20) 61421.569 62131.371 64658.5869 62758.8640 64157.9440 95407.957

```