### PR TITLE
new std(x) function in lines 67-71

### DIFF
--- a/perf.f90
+++ b/perf.f90
@@ -66,7 +66,8 @@ end function
 
 real(dp) function std(x) result(t)
 real(dp), intent(in) :: x(:)
-t = sqrt(mean(abs(x - mean(x))**2))
+n=size(x)
+t = sqrt(sum(x**2)/n -(sum(x)/n)**2)
 end function
 
 subroutine init_random_seed()


### PR DESCRIPTION
var(x)=E(x^2)=(E(x))^2. This form can save a few calculations compared to taking deviations from the mean. Saving the need to call mean(x) and relying only on Fortran functions.