### PR TITLE
Create GitHub workflow to run benchmark suite

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,5 +62,4 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
-        # run: JULIAHOME=~/julia make gh_action_benchmarks.csv
-        run: echo "Empty."
+        run: JULIAHOME=~/julia make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,6 +28,7 @@ jobs:
         rust-version: ['1.42.0']
         js-version: ['16.14.10']
         r-version: ['4.1.2']
+        lua-version: ['2.0.5']
     
     steps:
       - uses: actions/checkout@v2
@@ -87,6 +88,10 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
+      - name: "Set up LuaJit"
+        uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: luajit-${{ matrix.lua-version }}
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,6 @@ jobs:
         numpy-version: ['1.22']
         gfortran-version: ['9']
         rust-version: ['1.42.0']
-        go-version: ['1.17.4']
     
     steps:
       - uses: actions/checkout@v2
@@ -73,9 +72,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,6 +46,9 @@ jobs:
         uses: julia-actions/build-julia@v1
         with:
           ref: v${{ matrix.julia-version }}
+      - name: "Install Julia packages"
+        run: |
+          julia -e 'using Pkg; Pkg.add("Compat")'
       - name: "Setup dSFMT"
         run: |
           cd ~/

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,5 +75,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: |
-          find / -name 'libopenblas*'
-          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ BLASDIR=/usr/ make gh_action_benchmarks.csv
+          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,6 +46,15 @@ jobs:
         uses: julia-actions/build-julia@v1
         with:
           ref: v${{ matrix.julia-version }}
+      - name: "Download dSFMT"
+        run: |
+          cd ~/
+          mkdir -p dSFMT
+          cd dSFMT
+          wget https://github.com/MersenneTwister-Lab/dSFMT/archive/refs/tags/v2.2.4.tar.gz
+          echo "39682961ecfba621a98dbb6610b6ae2b7d6add450d4f08d8d4edd0e10abd8174 v2.2.4.tar.gz" | sha256sum --check --status
+          tar -xzf v2.2.4.tar.gz
+          mv dSFMT-*/* ./
       - name: "Set up Python"
         uses: actions/setup-python@v1
         with:
@@ -64,4 +73,4 @@ jobs:
       - name: "Run benchmark"
         run: |
           find ~/julia -name 'libopenblas*'
-          JULIAHOME=~/julia make gh_action_benchmarks.csv
+          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
         uses: julia-actions/build-julia@v1
         with:
           ref: v${{ matrix.julia-version }}
-      - name: "Download dSFMT"
+      - name: "Setup dSFMT"
         run: |
           cd ~/
           mkdir -p dSFMT
@@ -55,6 +55,10 @@ jobs:
           echo "39682961ecfba621a98dbb6610b6ae2b7d6add450d4f08d8d4edd0e10abd8174 v2.2.4.tar.gz" | sha256sum --check --status
           tar -xzf v2.2.4.tar.gz
           mv dSFMT-*/* ./
+      - name: "Setup OpenBLAS"
+        run: |
+          cd ~/julia/deps/srccache
+          tar -xzf OpenBLAS*
       - name: "Set up Python"
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,55 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        julia-version: ['1.7.1']
+        python-version: ['3.9']
+        # TODO: Add numpy version
+        gfortran-version: ['9']
+        rust-version: ['1.42.0']
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Update Ubuntu packages"
+        run: |
+          apt-get update
+          apt-get install -y aptitude
+          add-apt-repository ppa:ubuntu-toolchain-r/test
+          apt-get update
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1.6.0
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: "Install Julia source tree"
+        run: git clone https://github.com/JuliaLang/Julia $HOME/julia-src
+      - name: "Set up Python and NumPy"
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          pip-packages: numpy
+      - name: "Set up fortran"
+        run: apt-get install -y gfortran-${{ matrix.gfortran-version }}
+      - name: "Set up Rust"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust-version }}
+      - name: "Run benchmark"
+        run: JULIAHOME=$HOME/julia-src make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,6 +22,7 @@ jobs:
         os: [ubuntu-latest]
         julia-version: ['1.7.1']
         python-version: ['3.9']
+        numpy-version: ['1.22']
         # TODO: Add numpy version
         gfortran-version: ['9']
         rust-version: ['1.42.0']
@@ -40,11 +41,12 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: "Install Julia source tree"
         run: git clone https://github.com/JuliaLang/Julia $HOME/julia-src
-      - name: "Set up Python and NumPy"
+      - name: "Set up Python"
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-          pip-packages: numpy
+      - name: "Set up NumPy"
+        run: pip install numpy==${{ matrix.numpy-version }}
       - name: "Set up fortran"
         run: sudo apt-get install -y gfortran-${{ matrix.gfortran-version }}
       - name: "Set up Rust"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install Julia packages"
         run: |
           julia -e 'using Pkg; Pkg.add("Compat")'
-      - name: "Setup dSFMT"
+      - name: "Set up dSFMT"
         run: |
           cd ~/
           mkdir -p dSFMT
@@ -58,7 +58,7 @@ jobs:
           echo "39682961ecfba621a98dbb6610b6ae2b7d6add450d4f08d8d4edd0e10abd8174 v2.2.4.tar.gz" | sha256sum --check --status
           tar -xzf v2.2.4.tar.gz
           mv dSFMT-*/* ./
-      - name: "Setup OpenBLAS"
+      - name: "Set up OpenBLAS"
         run: |
           sudo apt-get install -y libopenblas-dev
       - name: "Set up Python"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/julia
-          key: ${{ runner.os }}-${{ matrix.julia-version }}
+          key: ${{ runner.os }}-v${{ matrix.julia-version }}
       - name: Build Julia
         if: steps.cache-julia.outputs.cache-hit != 'true'
         uses: julia-actions/build-julia@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,6 +25,7 @@ jobs:
         numpy-version: ['1.22']
         gfortran-version: ['9']
         rust-version: ['1.42.0']
+        go-version: ['1.17.4']
     
     steps:
       - uses: actions/checkout@v2
@@ -57,5 +58,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: JULIAHOME=~/julia make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,11 +24,12 @@ jobs:
         julia-version: ['1.7.1']
         python-version: ['3.9']
         numpy-version: ['1.22']
-        gfortran-version: ['9'] # Note: unused since is built-in.
+        gfortran-version: ['9']  # Note: unused since is built-in.
         rust-version: ['1.42.0']
         js-version: ['16']
         r-version: ['4.1.2']
-        lua-version: ['2.0.5']
+        lua-version: ['2.0.5']  # Note: Not used as benchmark is broken.
+        go-version: ['1.17.4']  # Note: Not used as benchmark is broken.
     
     steps:
       - uses: actions/checkout@v2
@@ -92,6 +93,10 @@ jobs:
         uses: leafo/gh-actions-lua@v8.0.0
         with:
           luaVersion: luajit-${{ matrix.lua-version }}
+      - name: "Set up Go"
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: |
-          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv
+          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.html

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,7 @@ jobs:
         gfortran-version: ['9'] # Note: unused since is built-in.
         rust-version: ['1.42.0']
         js-version: ['16.14.10']
+        r-version: ['4.1.2']
     
     steps:
       - uses: actions/checkout@v2
@@ -82,6 +83,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           nodejs-version: ${{ matrix.js-version }}
+      - name: "Set up R"
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r-version }}
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,7 @@ jobs:
         numpy-version: ['1.22']
         gfortran-version: ['9'] # Note: unused since is built-in.
         rust-version: ['1.42.0']
+        js-version: ['16.14.10']
     
     steps:
       - uses: actions/checkout@v2
@@ -77,6 +78,10 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
           cache: 'maven'
+      - name: "Set up JavaScript"
+        uses: actions/setup-node@v2
+        with:
+          nodejs-version: ${{ matrix.js-version }}
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,5 +72,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: |
-          find ~/julia -name 'libopenblas*'
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Update Ubuntu packages"
         run: |
-          apt-get update
-          apt-get install -y aptitude
-          add-apt-repository ppa:ubuntu-toolchain-r/test
-          apt-get update
+          sudo apt-get update
+          sudo apt-get install -y aptitude
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1.6.0
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,8 +39,6 @@ jobs:
         uses: julia-actions/setup-julia@v1.6.0
         with:
           version: ${{ matrix.julia-version }}
-      - name: "Install Julia source tree"
-        run: git clone https://github.com/JuliaLang/Julia $HOME/julia-src
       - name: "Set up Python"
         uses: actions/setup-python@v1
         with:
@@ -54,4 +52,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
       - name: "Run benchmark"
-        run: JULIAHOME=$HOME/julia-src make gh_action_benchmarks.csv
+        run: |
+          find / -name 'openblas' 2>/dev/null
+          JULIAHOME=$HOME/usr make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,12 +33,6 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
-      - name: "Update Ubuntu packages"
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y aptitude
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
       - name: "Cache Julia"
         id: cache-julia
         uses: actions/cache@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,4 +62,5 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
-        run: JULIAHOME=~/julia make gh_action_benchmarks.csv
+        # run: JULIAHOME=~/julia make gh_action_benchmarks.csv
+        run: echo "Empty."

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,3 +94,5 @@ jobs:
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.html
+      - name: "Print benchmark data"
+        run: cat gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
         julia-version: ['1.7.1']
         python-version: ['3.9']
         numpy-version: ['1.22']
-        gfortran-version: ['9']
+        gfortran-version: ['9'] # Note: unused since is built-in.
         rust-version: ['1.42.0']
     
     steps:
@@ -67,8 +67,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: "Set up NumPy"
         run: pip install numpy==${{ matrix.numpy-version }}
-      - name: "Set up fortran"
-        run: sudo apt-get install -y gfortran-${{ matrix.gfortran-version }}
       - name: "Set up Rust"
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-packages: numpy
       - name: "Set up fortran"
-        run: apt-get install -y gfortran-${{ matrix.gfortran-version }}
+        run: sudo apt-get install -y gfortran-${{ matrix.gfortran-version }}
       - name: "Set up Rust"
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,15 +1,21 @@
 name: Benchmarks
 
 on:
+  pull_request:
   push:
     branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'
+      - master
+    tags: '*'
   workflow_dispatch:
-    branches:
-      - '*'
+
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` or `release-*` branches
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -33,6 +39,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: "Cache Julia"
         id: cache-julia
         uses: actions/cache@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,6 @@ jobs:
         julia-version: ['1.7.1']
         python-version: ['3.9']
         numpy-version: ['1.22']
-        # TODO: Add numpy version
         gfortran-version: ['9']
         rust-version: ['1.42.0']
     
@@ -33,7 +32,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y aptitude
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1.6.0
@@ -52,6 +51,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
       - name: "Run benchmark"
-        run: |
-          find / -name 'openblas' 2>/dev/null
-          JULIAHOME=$HOME/usr make gh_action_benchmarks.csv
+        run: JULIAHOME=/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
       - name: "Set up JavaScript"
         uses: actions/setup-node@v2
         with:
-          nodejs-version: ${{ matrix.js-version }}
+          node-version: ${{ matrix.js-version }}
       - name: "Set up R"
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: ~/julia
           key: ${{ runner.os }}-v${{ matrix.julia-version }}
-      - name: Build Julia
+      - name: "Build Julia"
         if: steps.cache-julia.outputs.cache-hit != 'true'
         uses: julia-actions/build-julia@v1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,10 +34,17 @@ jobs:
           sudo apt-get install -y aptitude
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-      - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1.6.0
+      - name: "Cache Julia"
+        id: cache-julia
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.julia-version }}
+          path: ~/julia
+          key: ${{ runner.os }}-${{ matrix.julia-version }}
+      - name: Build Julia
+        if: steps.cache-julia.outputs.cache-hit != 'true'
+        uses: julia-actions/build-julia@v1
+        with:
+          ref: v${{ matrix.julia-version }}
       - name: "Set up Python"
         uses: actions/setup-python@v1
         with:
@@ -51,4 +58,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
       - name: "Run benchmark"
-        run: JULIAHOME=/ make gh_action_benchmarks.csv
+        run: JULIAHOME=~/julia make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
         numpy-version: ['1.22']
         gfortran-version: ['9'] # Note: unused since is built-in.
         rust-version: ['1.42.0']
-        js-version: ['16.14.10']
+        js-version: ['16']
         r-version: ['4.1.2']
         lua-version: ['2.0.5']
     

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ['3.9']
         numpy-version: ['1.22']
         gfortran-version: ['9']  # Note: unused since is built-in.
-        rust-version: ['1.42.0']
+        rust-version: ['1.42.0']  # Note: unused since controlled by `rust/rust-toolchain`
         js-version: ['16']
         r-version: ['4.1.2']
         lua-version: ['2.0.5']  # Note: Not used as benchmark is broken.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        java-version: ['17']
         julia-version: ['1.7.1']
         python-version: ['3.9']
         numpy-version: ['1.22']
@@ -72,6 +73,12 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
+      - name: "Set up Java"
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
       - name: "Run benchmark"
         run: |
           JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,7 +38,7 @@ jobs:
         go-version: ['1.17.4']  # Note: Not used as benchmark is broken.
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: "Cache Julia"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,8 +57,7 @@ jobs:
           mv dSFMT-*/* ./
       - name: "Setup OpenBLAS"
         run: |
-          cd ~/julia/deps/srccache
-          tar -xzf OpenBLAS*
+          sudo apt-get install -y libopenblas-dev
       - name: "Set up Python"
         uses: actions/setup-python@v1
         with:
@@ -76,4 +75,5 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
         run: |
-          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ make gh_action_benchmarks.csv
+          find / -name 'libopenblas*'
+          JULIAHOME=~/julia DSFMTDIR=~/dSFMT/ BLASDIR=/usr/ make gh_action_benchmarks.csv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,4 +62,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: "Run benchmark"
-        run: JULIAHOME=~/julia make gh_action_benchmarks.csv
+        run: |
+          find ~/julia -name 'libopenblas*'
+          JULIAHOME=~/julia make gh_action_benchmarks.csv

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ endif
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
 BLASMANIFEST=$(shell cat $(JULIAHOME)/usr/manifest/openblas)
-BLASDIR=$(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/
-LIBBLAS=$(BLASDIR)$(LIBBLASNAME).a
+BLASDIR=$(shell echo $(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/ | sed 's! !\\ !g'))
+LIBBLAS=$(shell echo $(BLASDIR)$(LIBBLASNAME).a | sed 's! !\\ !g')
 endif
 
 FFLAGS=-fexternal-blas

--- a/Makefile
+++ b/Makefile
@@ -131,20 +131,31 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; for t in 1 2 3 4 5; do cargo run --release -q; done >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
+GH_ACTION_LANGUAGES = c fortran julia python rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson
 #	scala, stata
 
 BENCHMARKS = $(foreach lang,$(LANGUAGES),benchmarks/$(lang).csv)
+GH_ACTION_BENCHMARKS = $(foreach lang,$(GH_ACTION_LANGUAGES),benchmarks/$(lang).csv)
 
 versions.csv: bin/versions.sh
 	$^ >$@
 
+gh_action_versions.csv: bin/versions.sh
+	bin/versions.sh ",c,fortran,julia,python,rust," >$@
+
 benchmarks.csv: bin/collect.jl $(BENCHMARKS)
 	@$(call PRINT_JULIA, $^ >$@)
 
+gh_action_benchmarks.csv: bin/collect.jl $(GH_ACTION_BENCHMARKS)
+	@$(call PRINT_JULIA, $^ >$@)
+
 benchmarks.html: bin/table.jl versions.csv benchmarks.csv
+	@$(call PRINT_JULIA, $^ >$@)
+
+gh_action_benchmarks.html: bin/table.jl gh_action_versions.csv gh_action_benchmarks.csv
 	@$(call PRINT_JULIA, $^ >$@)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 ifndef JULIAHOME
 $(error JULIAHOME not defined. Set value to the root of the Julia source tree.)
 endif
+ifndef DSFMTDIR
+$(error DSFMTDIR not defined. Set value to the root of the dSFMT source tree.)
+endif
+
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
 
@@ -44,9 +48,6 @@ ifeq ($(USE_SYSTEM_OPENLIBM), 0)
 LIBM = $(LIBMDIR)libopenlibm.a
 endif
 endif
-
-DSFMTDIR = $(JULIAHOME)/deps/scratch/dsfmt-$(DSFMT_VER)
-RMATHDIR = $(JULIAHOME)/deps/scratch/Rmath-julia-$(RMATH_JULIA_VER)
 
 default: benchmarks.html
 

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-# GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust
-GH_ACTION_LANGUAGES = lua r
+GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson
@@ -140,7 +139,7 @@ versions.csv: bin/versions.sh
 	$^ >$@
 
 gh_action_versions.csv: bin/versions.sh
-	bin/versions.sh ",c,fortran,java,javascript,julia,lua,python,r,rust," >$@
+	bin/versions.sh ",c,fortran,java,javascript,julia,python,r,rust," >$@
 
 benchmarks.csv: bin/collect.jl $(BENCHMARKS)
 	@$(call PRINT_JULIA, $^ >$@)

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-# GH_ACTION_LANGUAGES = c fortran java javascript julia python rust
-GH_ACTION_LANGUAGES = javascript r
+# GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust
+GH_ACTION_LANGUAGES = lua r
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson
@@ -140,7 +140,7 @@ versions.csv: bin/versions.sh
 	$^ >$@
 
 gh_action_versions.csv: bin/versions.sh
-	bin/versions.sh ",c,fortran,go,julia,python,rust," >$@
+	bin/versions.sh ",c,fortran,java,javascript,julia,lua,python,r,rust," >$@
 
 benchmarks.csv: bin/collect.jl $(BENCHMARKS)
 	@$(call PRINT_JULIA, $^ >$@)

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ endif
 
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
-# manifest contains `blasmanifest bb-uninstaller`, so we need to cut the second part:
-BLASDIR=$(JULIAHOME)/deps/srccache/
+BLASDIR=$(JULIAHOME)/usr/
 LIBBLAS=$(BLASDIR)/lib/$(LIBBLASNAME).dylib
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
 BLASMANIFEST=$(shell cat $(JULIAHOME)/usr/manifest/openblas)
-BLASDIR=$(shell echo $(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/ | sed 's! !\\ !g'))
+BLASDIR=$(shell echo $(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/ | sed 's! !\\ !g')
 LIBBLAS=$(shell echo $(BLASDIR)$(LIBBLASNAME).a | sed 's! !\\ !g')
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ endif
 
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
-BLASMANIFEST=$(shell cat $(JULIAHOME)/usr/manifest/openblas)
-BLASDIR=$(shell echo $(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/ | sed 's! !\\ !g')
-LIBBLAS=$(shell echo $(BLASDIR)$(LIBBLASNAME).a | sed 's! !\\ !g')
+# manifest contains `blasmanifest bb-uninstaller`, so we need to cut the second part:
+BLASMANIFEST=$(shell cat $(JULIAHOME)/usr/manifest/openblas | cut -d' ' -f1)
+BLASDIR=$(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/
+LIBBLAS=$(BLASDIR)$(LIBBLASNAME).a
 endif
 
 FFLAGS=-fexternal-blas

--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,13 @@ GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust
 BENCHMARKS = $(foreach lang,$(LANGUAGES),benchmarks/$(lang).csv)
 GH_ACTION_BENCHMARKS = $(foreach lang,$(GH_ACTION_LANGUAGES),benchmarks/$(lang).csv)
 
+COLON_SEPARATED_GHA_LANGUAGES = $(shell echo $(GH_ACTION_LANGUAGES) | sed 's/ /:/g')
+
 versions.csv: bin/versions.sh
 	$^ >$@
 
 gh_action_versions.csv: bin/versions.sh
-	bin/versions.sh ",c,fortran,java,javascript,julia,python,r,rust," >$@
+	$^ $(COLON_SEPARATED_GHA_LANGUAGES) >$@
 
 benchmarks.csv: bin/collect.jl $(BENCHMARKS)
 	@$(call PRINT_JULIA, $^ >$@)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
 
-NODEJSBIN = node8
+NODEJSBIN = node
 
 ITERATIONS=$(shell seq 1 5)
 
@@ -126,7 +126,8 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-GH_ACTION_LANGUAGES = c fortran java julia python rust
+# GH_ACTION_LANGUAGES = c fortran java javascript julia python rust
+GH_ACTION_LANGUAGES = javascript
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ endif
 ifndef DSFMTDIR
 $(error DSFMTDIR not defined. Set value to the root of the dSFMT source tree.)
 endif
+ifndef BLASDIR
+$(error BLASDIR not defined. Set value to the root of the OpenBLAS source tree.)
+endif
 
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
@@ -25,11 +28,7 @@ else
 MATHEMATICABIN = math
 endif
 
-#Which BLAS library am I using?
-ifeq ($(USE_SYSTEM_BLAS), 0)
-BLASDIR=$(JULIAHOME)/deps/srccache/
-LIBBLAS=$(BLASDIR)/lib/$(LIBBLASNAME).dylib
-endif
+LIBBLAS=$(BLASDIR)/lib/$(LIBBLASNAME).so
 
 FFLAGS=-fexternal-blas
 #gfortran cannot multiply matrices using 64-bit external BLAS.

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ benchmarks/fortran%.csv: bin/fperf%
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
-	#CGO_LDFLAGS="-lopenblas $(LIBM)" go get github.com/gonum/blas/cgo
+	CGO_LDFLAGS="-lopenblas $(LIBM)" go get github.com/gonum/blas/cgo
 	go get github.com/gonum/blas/blas64
-	go get github.com/gonum/blas/cgo
+	# go get github.com/gonum/blas/cgo
 	go get github.com/gonum/matrix/mat64
 	go get github.com/gonum/stat
 	$(foreach t,$(ITERATIONS), go run $<;) >$@
@@ -126,7 +126,8 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-GH_ACTION_LANGUAGES = c fortran go julia python rust
+# GH_ACTION_LANGUAGES = c fortran go julia python rust
+GH_ACTION_LANGUAGES = go julia python rust # Just for testing.
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ ifndef DSFMTDIR
 $(error DSFMTDIR not defined. Set value to the root of the dSFMT source tree.)
 endif
 
+
+# Will make multi-line targets work
+# (so we can use @for on the second line)
+.ONESHELL:
+
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
 
@@ -75,10 +80,10 @@ benchmarks/fortran.csv: \
 
 
 benchmarks/c%.csv: bin/perf%
-	$(foreach t,$(ITERATIONS), $<;) >$@
+	@for t in $(ITERATIONS); do $<; done >$@
 
 benchmarks/fortran%.csv: bin/fperf%
-	$(foreach t,$(ITERATIONS), $<;) >$@
+	@for t in $(ITERATIONS); do $<; done >$@
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
@@ -87,43 +92,47 @@ benchmarks/go.csv: perf.go
 	go get github.com/gonum/blas/cgo
 	go get github.com/gonum/matrix/mat64
 	go get github.com/gonum/stat
-	$(foreach t,$(ITERATIONS), go run $<;) >$@
+	@for t in $(ITERATIONS); do go run $<; done >$@
 
 benchmarks/julia.csv: perf.jl
-	$(foreach t,$(ITERATIONS), $(JULIAHOME)/usr/bin/julia $<;) >$@
+	@for t in $(ITERATIONS); do $(JULIAHOME)/usr/bin/julia $<; done >$@
 
 benchmarks/python.csv: perf.py
-	$(foreach t,$(ITERATIONS), $(PYTHON) $<;) >$@
+	@for t in $(ITERATIONS); do $(PYTHON) $<; done >$@
 
 benchmarks/matlab.csv: perf.m
-	$(foreach t,$(ITERATIONS), matlab -nojvm -singleCompThread -r 'perf; perf; exit' | grep ^matlab | tail -8;) >$@
+	@for t in $(ITERATIONS); do matlab -nojvm -singleCompThread -r 'perf; perf; exit' | grep ^matlab | tail -8; done >$@
 
 benchmarks/octave.csv: perf.m
-	$(foreach t,$(ITERATIONS), $(OCTAVE) -q --eval perf 2>/dev/null;) >$@
+	@for t in $(ITERATIONS); do $(OCTAVE) -q --eval perf 2>/dev/null; done >$@
 
 benchmarks/r.csv: perf.R
-	$(foreach t,$(ITERATIONS), cat $< | R --vanilla --slave 2>/dev/null;) >$@
+	@for t in $(ITERATIONS); do cat $< | R --vanilla --slave 2>/dev/null; done >$@
 
 benchmarks/javascript.csv: perf.js
-	$(foreach t,$(ITERATIONS), $(NODEJSBIN) $<;) >$@
+	@for t in $(ITERATIONS); do $(NODEJSBIN) $<; done >$@
 
 benchmarks/mathematica.csv: perf.nb
-	$(foreach t,$(ITERATIONS), $(MATHEMATICABIN) -noprompt -run "<<$<; Exit[]";) >$@
+	@for t in $(ITERATIONS); do $(MATHEMATICABIN) -noprompt -run "<<$<; Exit[]"; done >$@
 
 benchmarks/stata.csv: perf.do
-	$(foreach t,$(ITERATIONS), stata -b do $^ $@;)
+	@for t in $(ITERATIONS); do stata -b do $^ $@; done
 
 benchmarks/lua.csv: perf.lua
-	$(foreach t,$(ITERATIONS), luajit $<;) >$@
+	@for t in $(ITERATIONS); do luajit $<; done >$@
 
 benchmarks/java.csv: java/src/main/java/PerfBLAS.java
-	cd java; sh setup.sh; $(foreach t,$(ITERATIONS), mvn -q exec:java;) >../$@
+	cd java
+	sh setup.sh
+	@for t in $(ITERATIONS); do mvn -q exec:java; done >../$@
 
 benchmarks/scala.csv: scala/src/main/scala/perf.scala scala/build.sbt
-	cd scala; $(foreach t,$(ITERATIONS), sbt run;) >../$@
+	cd scala
+	@for t in $(ITERATIONS); do sbt run; done >../$@
 
 benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
-	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
+	cd rust
+	@for t in $(ITERATIONS); do cargo run --release -q; done >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
 GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ endif
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
 # manifest contains `blasmanifest bb-uninstaller`, so we need to cut the second part:
-BLASMANIFEST=$(shell cat $(JULIAHOME)/usr/manifest/openblas | cut -d' ' -f1)
-BLASDIR=$(JULIAHOME)/deps/scratch/$(BLASMANIFEST)/
-LIBBLAS=$(BLASDIR)$(LIBBLASNAME).a
+BLASDIR=$(JULIAHOME)/deps/srccache/
+LIBBLAS=$(BLASDIR)/lib/$(LIBBLASNAME).dylib
 endif
 
 FFLAGS=-fexternal-blas
@@ -56,7 +55,7 @@ export GOTO_NUM_THREADS=1
 export OPENBLAS_NUM_THREADS=1
 
 perf.h: $(JULIAHOME)/deps/Versions.make
-	echo '#include "$(BLASDIR)cblas.h"' > $@
+	echo '#include "$(BLASDIR)/include/cblas.h"' > $@
 	echo '#include "$(DSFMTDIR)/dSFMT.c"' >> $@
 
 bin/perf%: perf.c perf.h

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ include $(JULIAHOME)/deps/Versions.make
 
 NODEJSBIN = node8
 
+ITERATIONS=$(shell seq 1 5)
+
 #Use python2 for Python 2.x
 PYTHON = python3
 
@@ -80,10 +82,10 @@ benchmarks/fortran.csv: \
 
 
 benchmarks/c%.csv: bin/perf%
-	for t in 1 2 3 4 5; do $<; done >$@
+	$(foreach t,$(ITERATIONS), $<;) >$@
 
 benchmarks/fortran%.csv: bin/fperf%
-	for t in 1 2 3 4 5; do $<; done >$@
+	$(foreach t,$(ITERATIONS), $<;) >$@
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
@@ -92,43 +94,43 @@ benchmarks/go.csv: perf.go
 	go get github.com/gonum/blas/cgo
 	go get github.com/gonum/matrix/mat64
 	go get github.com/gonum/stat
-	for t in 1 2 3 4 5; do go run $<; done >$@
+	$(foreach t,$(ITERATIONS), go run $<;) >$@
 
 benchmarks/julia.csv: perf.jl
-	for t in 1 2 3 4 5; do $(JULIAHOME)/usr/bin/julia $<; done >$@
+	$(foreach t,$(ITERATIONS), $(JULIAHOME)/usr/bin/julia $<;) >$@
 
 benchmarks/python.csv: perf.py
-	for t in 1 2 3 4 5; do $(PYTHON) $<; done >$@
+	$(foreach t,$(ITERATIONS), $(PYTHON) $<;) >$@
 
 benchmarks/matlab.csv: perf.m
-	for t in 1 2 3 4 5; do matlab -nojvm -singleCompThread -r 'perf; perf; exit' | grep ^matlab | tail -8; done >$@
+	$(foreach t,$(ITERATIONS), matlab -nojvm -singleCompThread -r 'perf; perf; exit' | grep ^matlab | tail -8;) >$@
 
 benchmarks/octave.csv: perf.m
-	for t in 1 2 3 4 5; do $(OCTAVE) -q --eval perf 2>/dev/null; done >$@
+	$(foreach t,$(ITERATIONS), $(OCTAVE) -q --eval perf 2>/dev/null;) >$@
 
 benchmarks/r.csv: perf.R
-	for t in 1 2 3 4 5; do cat $< | R --vanilla --slave 2>/dev/null; done >$@
+	$(foreach t,$(ITERATIONS), cat $< | R --vanilla --slave 2>/dev/null;) >$@
 
 benchmarks/javascript.csv: perf.js
-	for t in 1 2 3 4 5; do $(NODEJSBIN) $<; done >$@
+	$(foreach t,$(ITERATIONS), $(NODEJSBIN) $<;) >$@
 
 benchmarks/mathematica.csv: perf.nb
-	for t in 1 2 3 4 5; do $(MATHEMATICABIN) -noprompt -run "<<$<; Exit[]"; done >$@
+	$(foreach t,$(ITERATIONS), $(MATHEMATICABIN) -noprompt -run "<<$<; Exit[]";) >$@
 
 benchmarks/stata.csv: perf.do
-	for t in 1 2 3 4 5; do stata -b do $^ $@; done
+	$(foreach t,$(ITERATIONS), stata -b do $^ $@;)
 
 benchmarks/lua.csv: perf.lua
-	for t in 1 2 3 4 5; do scilua $<; done >$@
+	$(foreach t,$(ITERATIONS), scilua $<;) >$@
 
 benchmarks/java.csv: java/src/main/java/PerfBLAS.java
-	cd java; sh setup.sh; for t in 1 2 3 4 5; do mvn -q exec:java; done >../$@
+	cd java; sh setup.sh; $(foreach t,$(ITERATIONS), mvn -q exec:java;) >../$@
 
 benchmarks/scala.csv: scala/src/main/scala/perf.scala scala/build.sbt
-	cd scala; for t in 1 2 3 4 5; do sbt run; done >../$@
+	cd scala; $(foreach t,$(ITERATIONS), sbt run;) >../$@
 
 benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
-	cd rust; for t in 1 2 3 4 5; do cargo run --release -q; done >../$@
+	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
 GH_ACTION_LANGUAGES = c fortran go julia python rust

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,7 @@ benchmarks/fortran%.csv: bin/fperf%
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
-	CGO_LDFLAGS="-lopenblas $(LIBM)" go get github.com/gonum/blas/cgo
-	go get github.com/gonum/blas/blas64
-	# go get github.com/gonum/blas/cgo
-	go get github.com/gonum/matrix/mat64
-	go get github.com/gonum/stat
+	go get gonum.org/v1/gonum@v0.9.3
 	$(foreach t,$(ITERATIONS), go run $<;) >$@
 
 benchmarks/julia.csv: perf.jl

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ benchmarks/stata.csv: perf.do
 	$(foreach t,$(ITERATIONS), stata -b do $^ $@;)
 
 benchmarks/lua.csv: perf.lua
-	$(foreach t,$(ITERATIONS), scilua $<;) >$@
+	$(foreach t,$(ITERATIONS), luajit $<;) >$@
 
 benchmarks/java.csv: java/src/main/java/PerfBLAS.java
 	cd java; sh setup.sh; $(foreach t,$(ITERATIONS), mvn -q exec:java;) >../$@

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; for t in 1 2 3 4 5; do cargo run --release -q; done >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-GH_ACTION_LANGUAGES = c fortran julia python rust
+GH_ACTION_LANGUAGES = c fortran go julia python rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson
@@ -144,7 +144,7 @@ versions.csv: bin/versions.sh
 	$^ >$@
 
 gh_action_versions.csv: bin/versions.sh
-	bin/versions.sh ",c,fortran,julia,python,rust," >$@
+	bin/versions.sh ",c,fortran,go,julia,python,rust," >$@
 
 benchmarks.csv: bin/collect.jl $(BENCHMARKS)
 	@$(call PRINT_JULIA, $^ >$@)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
 # GH_ACTION_LANGUAGES = c fortran java javascript julia python rust
-GH_ACTION_LANGUAGES = javascript
+GH_ACTION_LANGUAGES = javascript r
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,11 @@ benchmarks/fortran%.csv: bin/fperf%
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
-	go get gonum.org/v1/gonum@v0.9.3
+	#CGO_LDFLAGS="-lopenblas $(LIBM)" go get github.com/gonum/blas/cgo
+	go get github.com/gonum/blas/blas64
+	go get github.com/gonum/blas/cgo
+	go get github.com/gonum/matrix/mat64
+	go get github.com/gonum/stat
 	$(foreach t,$(ITERATIONS), go run $<;) >$@
 
 benchmarks/julia.csv: perf.jl
@@ -122,8 +126,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-# GH_ACTION_LANGUAGES = c fortran go julia python rust
-GH_ACTION_LANGUAGES = go julia python rust # Just for testing.
+GH_ACTION_LANGUAGES = c fortran julia python rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	cd rust; $(foreach t,$(ITERATIONS), cargo run --release -q;) >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-GH_ACTION_LANGUAGES = c fortran julia python rust
+GH_ACTION_LANGUAGES = c fortran java julia python rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
-BLASDIR=$(JULIAHOME)/usr/
+BLASDIR=$(JULIAHOME)/deps/srccache/
 LIBBLAS=$(BLASDIR)/lib/$(LIBBLASNAME).dylib
 endif
 

--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -27,7 +27,7 @@ fi
 
 if [[ $LANGUAGES == *",javascript,"* ]]; then
     echo -n "javascript,V8 "
-    node8 -e "console.log(process.versions.v8)"
+    node -e "console.log(process.versions.v8)"
 fi
 
 if [[ $LANGUAGES == *",julia,"* ]]; then

--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -1,41 +1,72 @@
 #!/usr/bin/env bash
 
-echo -n "c,gcc "
-gcc -v 2>&1 | grep "gcc version" | cut -f3 -d" "
+# User argument declaring what languages to query:
+DEFAULT_LANGUAGES=",c,fortran,go,java,javascript,julia,lua,mathematica,matlab,octave,python,r,rust,"
+LANGUAGES=${1:-DEFAULT_LANGUAGES}
 
-echo -n "fortran,gcc "
-gfortran -v 2>&1 | grep "gcc version" | cut -f3 -d" "
+# Check if ",c," in languages:
+if [[ $LANGUAGES == *",c,"* ]]; then
+    echo -n "c,gcc "
+    gcc -v 2>&1 | grep "gcc version" | cut -f3 -d" "
+fi
 
-echo -n go,
-go version | cut -f3 -d" "
+if [[ $LANGUAGES == *",fortran,"* ]]; then
+    echo -n "fortran,gcc "
+    gfortran -v 2>&1 | grep "gcc version" | cut -f3 -d" "
+fi
 
-echo -n java,
-java -version 2>&1 |grep "version" | cut -f3 -d " " | cut -c 2-9
+if [[ $LANGUAGES == *",go,"* ]]; then
+    echo -n go,
+    go version | cut -f3 -d" "
+fi
 
-echo -n "javascript,V8 "
-node8 -e "console.log(process.versions.v8)"
+if [[ $LANGUAGES == *",java,"* ]]; then
+    echo -n java,
+    java -version 2>&1 |grep "version" | cut -f3 -d " " | cut -c 2-9
+fi
 
-echo -n "julia,"
-$JULIAHOME/usr/bin/julia -v | cut -f3 -d" "
+if [[ $LANGUAGES == *",javascript,"* ]]; then
+    echo -n "javascript,V8 "
+    node8 -e "console.log(process.versions.v8)"
+fi
 
-echo -n "lua,"
-# scilua -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,
-echo scilua v1.0.0-b12
+if [[ $LANGUAGES == *",julia,"* ]]; then
+    echo -n "julia,"
+    $JULIAHOME/usr/bin/julia -v | cut -f3 -d" "
+fi
 
-echo -n "mathematica,"
-echo quit | math -version | head -n 1 | cut -f2 -d" "
+if [[ $LANGUAGES == *",lua,"* ]]; then
+    echo -n "lua,"
+    # scilua -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,
+    echo scilua v1.0.0-b12
+fi
 
-echo -n "matlab,R"
-matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n3 | head -n1 | cut -f5 -d" " | sed "s/'//g"
+if [[ $LANGUAGES == *",mathematica,"* ]]; then
+    echo -n "mathematica,"
+    echo quit | math -version | head -n 1 | cut -f2 -d" "
+fi
 
-echo -n "octave,"
-octave-cli -v | grep version | cut -f4 -d" "
+if [[ $LANGUAGES == *",matlab,"* ]]; then
+    echo -n "matlab,R"
+    matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n3 | head -n1 | cut -f5 -d" " | sed "s/'//g"
+fi
 
-echo -n "python,"
-python3 -V 2>&1 | cut -f2 -d" "
+if [[ $LANGUAGES == *",octave,"* ]]; then
+    echo -n "octave,"
+    octave-cli -v | grep version | cut -f4 -d" "
+fi
 
-echo -n "r,"
-R --version | grep "R version" | cut -f3 -d" "
+if [[ $LANGUAGES == *",python,"* ]]; then
+    echo -n "python,"
+    python3 -V 2>&1 | cut -f2 -d" "
+fi
 
-echo -n "rust,"
-(cd rust; rustc --version | cut -c 7- | sed 's/ ([0-9a-f]* /<br>(/g')
+if [[ $LANGUAGES == *",r,"* ]]; then
+    echo -n "r,"
+    R --version | grep "R version" | cut -f3 -d" "
+fi
+
+if [[ $LANGUAGES == *",rust,"* ]]; then
+    echo -n "rust,"
+    (cd rust; rustc --version | cut -c 7- | sed 's/ ([0-9a-f]* /<br>(/g')
+fi

--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -1,72 +1,74 @@
 #!/usr/bin/env bash
 
 # User argument declaring what languages to query:
-DEFAULT_LANGUAGES=",c,fortran,go,java,javascript,julia,lua,mathematica,matlab,octave,python,r,rust,"
+DEFAULT_LANGUAGES="c:fortran:go:java:javascript:julia:lua:mathematica:matlab:octave:python:r:rust"
 LANGUAGES=${1:-DEFAULT_LANGUAGES}
 
-# Check if ",c," in languages:
-if [[ $LANGUAGES == *",c,"* ]]; then
+LANGUAGES=":${LANGUAGES}:"
+
+# Check if ":c:" in languages:
+if [[ $LANGUAGES == *":c:"* ]]; then
     echo -n "c,gcc "
     gcc -v 2>&1 | grep "gcc version" | cut -f3 -d" "
 fi
 
-if [[ $LANGUAGES == *",fortran,"* ]]; then
+if [[ $LANGUAGES == *":fortran:"* ]]; then
     echo -n "fortran,gcc "
     gfortran -v 2>&1 | grep "gcc version" | cut -f3 -d" "
 fi
 
-if [[ $LANGUAGES == *",go,"* ]]; then
+if [[ $LANGUAGES == *":go:"* ]]; then
     echo -n go,
     go version | cut -f3 -d" "
 fi
 
-if [[ $LANGUAGES == *",java,"* ]]; then
+if [[ $LANGUAGES == *":java:"* ]]; then
     echo -n java,
     java -version 2>&1 |grep "version" | cut -f3 -d " " | cut -c 2-9
 fi
 
-if [[ $LANGUAGES == *",javascript,"* ]]; then
+if [[ $LANGUAGES == *":javascript:"* ]]; then
     echo -n "javascript,V8 "
     node -e "console.log(process.versions.v8)"
 fi
 
-if [[ $LANGUAGES == *",julia,"* ]]; then
+if [[ $LANGUAGES == *":julia:"* ]]; then
     echo -n "julia,"
     $JULIAHOME/usr/bin/julia -v | cut -f3 -d" "
 fi
 
-if [[ $LANGUAGES == *",lua,"* ]]; then
+if [[ $LANGUAGES == *":lua:"* ]]; then
     echo -n "lua,"
     # scilua -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,
     echo scilua v1.0.0-b12
 fi
 
-if [[ $LANGUAGES == *",mathematica,"* ]]; then
+if [[ $LANGUAGES == *":mathematica:"* ]]; then
     echo -n "mathematica,"
     echo quit | math -version | head -n 1 | cut -f2 -d" "
 fi
 
-if [[ $LANGUAGES == *",matlab,"* ]]; then
+if [[ $LANGUAGES == *":matlab:"* ]]; then
     echo -n "matlab,R"
     matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n3 | head -n1 | cut -f5 -d" " | sed "s/'//g"
 fi
 
-if [[ $LANGUAGES == *",octave,"* ]]; then
+if [[ $LANGUAGES == *":octave:"* ]]; then
     echo -n "octave,"
     octave-cli -v | grep version | cut -f4 -d" "
 fi
 
-if [[ $LANGUAGES == *",python,"* ]]; then
+if [[ $LANGUAGES == *":python:"* ]]; then
     echo -n "python,"
     python3 -V 2>&1 | cut -f2 -d" "
 fi
 
-if [[ $LANGUAGES == *",r,"* ]]; then
+if [[ $LANGUAGES == *":r:"* ]]; then
     echo -n "r,"
     R --version | grep "R version" | cut -f3 -d" "
 fi
 
-if [[ $LANGUAGES == *",rust,"* ]]; then
+if [[ $LANGUAGES == *":rust:"* ]]; then
     echo -n "rust,"
     (cd rust; rustc --version | cut -c 7- | sed 's/ ([0-9a-f]* /<br>(/g')
 fi

--- a/perf.go
+++ b/perf.go
@@ -3,7 +3,9 @@
 // Three gonum packages must be installed, and then an additional environment
 // variable must be set to use the BLAS installation.
 // To install the gonum packages, run:
-// 		go get gonum.org/v1/gonum
+// 		go get github.com/gonum/blas
+//		go get github.com/gonum/matrix/mat64
+//		go get github.com/gonum/stat
 // The cgo ldflags must then be set to use the BLAS implementation. As an example,
 // download OpenBLAS to ~/software
 //		git clone https://github.com/xianyi/OpenBLAS
@@ -25,7 +27,10 @@ import (
 	"os"
 	"bufio"
 
-	"gonum.org/v1/gonum"
+	"github.com/gonum/blas/blas64"
+	"github.com/gonum/blas/cgo"
+	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/stat"
 )
 
 func init() {

--- a/perf.go
+++ b/perf.go
@@ -3,9 +3,7 @@
 // Three gonum packages must be installed, and then an additional environment
 // variable must be set to use the BLAS installation.
 // To install the gonum packages, run:
-// 		go get github.com/gonum/blas
-//		go get github.com/gonum/matrix/mat64
-//		go get github.com/gonum/stat
+// 		go get gonum.org/v1/gonum
 // The cgo ldflags must then be set to use the BLAS implementation. As an example,
 // download OpenBLAS to ~/software
 //		git clone https://github.com/xianyi/OpenBLAS
@@ -27,10 +25,7 @@ import (
 	"os"
 	"bufio"
 
-	"github.com/gonum/blas/blas64"
-	"github.com/gonum/blas/cgo"
-	"github.com/gonum/matrix/mat64"
-	"github.com/gonum/stat"
+	"gonum.org/v1/gonum"
 )
 
 func init() {


### PR DESCRIPTION
GitHub actions are desirable for running benchmarks for a variety of reasons:

1. Consistent across runs (see https://labs.quansight.org/blog/2021/08/github-actions-benchmarks/)
2. Can be run on a schedule or on a trigger (e.g., every new Julia tag), without needing someone to run on their own machine
3. Makes it easy to set up various languages, as there is usually a GitHub action that someone has already set up
4. Lets you change versions of these languages easily

This GitHub action successfully runs a subset of the languages and generates the csv data. The workflow runs for the following languages:
- C, fortran, java, javascript, julia, python, R, and rust.

The following benchmarks are not part of the workflow, for the reasons given below:
- Lua, Go (install fine, but the benchmarks themselves are broken)
- Octave (no maintained github action)
- Mathematica, MATLAB (proprietary)


Current result (it prints the csv at the end):
```
c,iteration_pi_sum,8.028984
c,matrix_multiply,43.012142
c,matrix_statistics,5.007982
c,parse_integers,0.19634
c,print_to_file,20.508051
c,recursion_fibonacci,0.025188
c,recursion_quicksort,0.422955
c,userfunc_mandelbrot,0.08167
fortran,iteration_pi_sum,8.028663
fortran,matrix_multiply,57.163952
fortran,matrix_statistics,8.046266
fortran,parse_integers,0.753935
fortran,print_to_file,113.916496
fortran,recursion_fibonacci,4.4e-5
fortran,recursion_quicksort,0.483927
fortran,userfunc_mandelbrot,7.8e-5
java,iteration_pi_sum,16.370829
java,iteration_sinc_sum,0.049201
java,matrix_multiply,788.083768
java,matrix_statistics,30.276736
java,parse_integers,0.274402
java,print_to_file,99.797282
java,recursion_fibonacci,0.0424
java,recursion_quicksort,1.006608
java,userfunc_mandelbrot,0.136501
javascript,iteration_pi_sum,10.5
javascript,matrix_multiply,2900.0
javascript,matrix_statistics,46.9
javascript,parse_integers,0.64
javascript,print_to_file,118.0
javascript,recursion_fibonacci,0.109
javascript,recursion_quicksort,1.61
javascript,userfunc_mandelbrot,0.149
julia,iteration_pi_sum,8.028063
julia,matrix_multiply,33.387676
julia,matrix_statistics,8.219065
julia,parse_integers,0.137201
julia,print_to_file,18.368588
julia,recursion_fibonacci,0.0482
julia,recursion_quicksort,0.469904
julia,userfunc_mandelbrot,0.0796
python,iteration_pi_sum,630.6591033935547
python,matrix_multiply,49.559593200683594
python,matrix_statistics,51.499128341674805
python,parse_integers,1.6732215881347656
python,print_to_file,54.22806739807129
python,recursion_fibonacci,2.522706985473633
python,recursion_quicksort,11.09170913696289
python,userfunc_mandelbrot,6.908893585205078
r,iteration_pi_sum,236.0
r,matrix_multiply,116.0
r,matrix_statistics,78.0
r,parse_integers,4.0
r,print_to_file,1325.0
r,recursion_fibonacci,10.0
r,recursion_quicksort,22.0
r,userfunc_mandelbrot,20.0
rust,iteration_pi_sum,8.029562
rust,matrix_multiply,46.196557
rust,matrix_statistics,6.52925
rust,parse_integers,0.186271
rust,print_to_file,11.194186
rust,recursion_fibonacci,0.046293
rust,recursion_quicksort,0.428904
rust,userfunc_mandelbrot,0.080522
```