### PR TITLE
fix java string format

### DIFF
--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -24,7 +24,7 @@ fi
 
 if [[ $LANGUAGES == *":java:"* ]]; then
     echo -n java,
-    java -version 2>&1 |grep "version" | cut -f3 -d " " | cut -c 2-9
+    java -version 2>&1 | grep "version" | cut -f2 -d "\""
 fi
 
 if [[ $LANGUAGES == *":javascript:"* ]]; then


### PR DESCRIPTION
Just a small format fix:

Previous:
```
java,17.0.3"
```
After:
```
java,17.0.3
```