### PR TITLE
[Go]: migrate to gonum.org/v1 packages

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
         js-version: ['16']
         r-version: ['4.1.2']
         lua-version: ['2.0.5']  # Note: Not used as benchmark is broken.
-        go-version: ['1.17.4']  # Note: Not used as benchmark is broken.
+        go-version: ['1.17.4']
     
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ benchmarks/fortran%.csv: bin/fperf%
 
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
-	#CGO_LDFLAGS="-lopenblas $(LIBM)" go get github.com/gonum/blas/cgo
-	go get github.com/gonum/blas/blas64
-	go get github.com/gonum/blas/cgo
-	go get github.com/gonum/matrix/mat64
-	go get github.com/gonum/stat
+	go env -w GO111MODULE=off
+	export CGO_LDFLAGS="-L${LIBM} -lopenblas"
+	go get gonum.org/v1/netlib/blas/netlib
+	go get gonum.org/v1/gonum/mat
+	go get gonum.org/v1/gonum/stat
 	@for t in $(ITERATIONS); do go run $<; done >$@
 
 benchmarks/julia.csv: perf.jl
@@ -135,7 +135,7 @@ benchmarks/rust.csv: rust/src/main.rs rust/src/util.rs rust/Cargo.lock
 	@for t in $(ITERATIONS); do cargo run --release -q; done >../$@
 
 LANGUAGES = c fortran go java javascript julia lua mathematica matlab octave python r rust
-GH_ACTION_LANGUAGES = c fortran java javascript julia python r rust
+GH_ACTION_LANGUAGES = c fortran go java javascript julia python r rust
 
 # These were formerly listed in LANGUAGES, but I can't get them to run
 # 2017-09-27 johnfgibson

--- a/perf.go
+++ b/perf.go
@@ -234,7 +234,7 @@ func main() {
 
 func runBenchmarkFor(fn func(*testing.B)) (seconds float64, err error) {
 	bm := testing.Benchmark(fn)
-	if (bm == testing.BenchmarkResult{}) {
+	if (bm.N == 0) {
 		return 0, errors.New("failed")
 	}
 	return bm.T.Seconds() / float64(bm.N), nil


### PR DESCRIPTION
This is to update go tests so that we can get them up and running in the CI.

Supersedes and closes #27 