### PR TITLE
fix benchmarks link on julia website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is a collection of micro-benchmarks used to compare Julia's performance aga
 that of other languages.
 It was formerly part of the Julia source tree.
 The results of these benchmarks are used to generate the performance graph on the
-[Julia homepage](https://julialang.org) and the table on the
-[benchmarks page](https://julialang.org/benchmarks).
+[Julia benchmarks page](https://julialang.org/benchmarks).
 
 ## Running benchmarks
 

--- a/bin/table.jl
+++ b/bin/table.jl
@@ -1,7 +1,6 @@
 #!/usr/bin/env julia
 
-# This script generates the table published at https://julialang.org/benchmarks/
-# (file _includes/benchmarks.html in the JuliaLang/julialang.github.com repository)
+# This script generates an HTML table with the benchmark values and language versions.
 
 using Compat
 import Compat.Statistics


### PR DESCRIPTION
Benchmarks are not located on the homepage anymore

The website does not include the table anymore