### PR TITLE
remove compat usage

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,8 +27,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: ['17']
-        julia-version: ['1.7.1']
-        python-version: ['3.9']
+        julia-version: ['1.7.3']
+        python-version: ['3.10']
         numpy-version: ['1.22']
         gfortran-version: ['9']  # Note: unused since is built-in.
         rust-version: ['1.42.0']  # Note: unused since controlled by `rust/rust-toolchain`
@@ -36,7 +36,7 @@ jobs:
         r-version: ['4.1.2']
         lua-version: ['latest']  # Note: unused since lua distribution manually downloaded
         go-version: ['1.17.4']
-    
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -52,9 +52,6 @@ jobs:
         uses: julia-actions/build-julia@v1
         with:
           ref: v${{ matrix.julia-version }}
-      - name: "Install Julia packages"
-        run: |
-          julia -e 'using Pkg; Pkg.add("Compat")'
       - name: "Set up dSFMT"
         run: |
           cd ~/

--- a/bin/table.jl
+++ b/bin/table.jl
@@ -2,9 +2,8 @@
 
 # This script generates an HTML table with the benchmark values and language versions.
 
-using Compat
-import Compat.Statistics
-import Compat.Printf
+import Statistics
+import Printf
 
 const benchmark_order = [
     "iteration_pi_sum",
@@ -54,10 +53,10 @@ function lang_by(lang::String)
     # C is placed at the start of the list
     lang == "c" ? -Inf :
     # Julia is sorted immediately after C
-    @compat lang == "julia" ? -floatmax() :
+    lang == "julia" ? -floatmax() :
     # The rest of the languages are sorted by the geometric mean of their benchmark values
     # See https://en.wikipedia.org/wiki/Geometric_mean#Relationship_with_logarithms for details
-    @compat exp(Statistics.mean(log.(collect(values(benchmarks[lang])))))
+    exp(Statistics.mean(log.(collect(values(benchmarks[lang])))))
 end
 
 const language_order = sort!(collect(keys(benchmarks)), by=lang_by)
@@ -101,7 +100,7 @@ for benchmark in benchmark_order
     for lang in language_order
         rel_time = "n/a"
         if haskey(benchmarks[lang], benchmark)
-            @compat rel_time = Printf.@sprintf "%.2f" benchmarks[lang][benchmark]/c_time
+            rel_time = Printf.@sprintf "%.2f" benchmarks[lang][benchmark]/c_time
         end
         println("            <td class=\"data\">$rel_time</td>")
     end

--- a/perf.jl
+++ b/perf.jl
@@ -1,12 +1,10 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-using Compat
-
-import Compat.LinearAlgebra
-import Compat.Test
-import Compat.Printf
-import Compat.Statistics
-import Compat.Sys
+import LinearAlgebra
+import Test
+import Printf
+import Statistics
+import Base.Sys
 
 include("./perfutil.jl")
 
@@ -14,7 +12,7 @@ include("./perfutil.jl")
 
 fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)
 
-@compat Test.@test fib(20) == 6765
+Test.@test fib(20) == 6765
 @timeit fib(20) "recursion_fibonacci" "Recursive fibonacci"
 
 ## parse integer ##
@@ -39,12 +37,12 @@ end
 
 ## array constructors ##
 
-@compat Test.@test all(fill(1.,200,200) .== 1)
+Test.@test all(fill(1.,200,200) .== 1)
 
 ## matmul and transpose ##
 
 A = fill(1.,200,200)
-@compat Test.@test all(A*A' .== 200)
+Test.@test all(A*A' .== 200)
 # @timeit A*A' "AtA" "description"
 
 ## mandelbrot set: complex arithmetic and comprehensions ##
@@ -66,7 +64,7 @@ function mandel(z)
 end
 
 mandelperf() = [ mandel(complex(r,i)) for i=-1.:.1:1., r=-2.0:.1:0.5 ]
-@compat Test.@test sum(mandelperf()) == 14791
+Test.@test sum(mandelperf()) == 14791
 @timeit mandelperf() "userfunc_mandelbrot" "Calculation of mandelbrot set"
 
 ## numeric vector sort ##
@@ -90,7 +88,7 @@ function qsort!(a,lo,hi)
 end
 
 sortperf(n) = qsort!(rand(n), 1, n)
-@compat Test.@test issorted(sortperf(5000))
+Test.@test issorted(sortperf(5000))
 @timeit sortperf(5000) "recursion_quicksort" "Sorting of random numbers using quicksort"
 
 ## slow pi series ##
@@ -106,7 +104,7 @@ function pisum()
     sum
 end
 
-@compat Test.@test abs(pisum()-1.644834071848065) < 1e-12
+Test.@test abs(pisum()-1.644834071848065) < 1e-12
 @timeit pisum() "iteration_pi_sum" "Summation of a power series"
 
 ## slow pi series, vectorized ##
@@ -144,11 +142,11 @@ function randmatstat(t)
             w[i] = trace((Q'*Q)^4)
         end
     end
-    @compat return (Statistics.std(v)/Statistics.mean(v), Statistics.std(w)/Statistics.mean(w))
+    return (Statistics.std(v)/Statistics.mean(v), Statistics.std(w)/Statistics.mean(w))
 end
 
 (s1, s2) = randmatstat(1000)
-@compat Test.@test 0.5 < s1 < 1.0 && 0.5 < s2 < 1.0
+Test.@test 0.5 < s1 < 1.0 && 0.5 < s2 < 1.0
 @timeit randmatstat(1000) "matrix_statistics" "Statistics on a random matrix"
 
 ## largish random number gen & matmul ##
@@ -157,11 +155,11 @@ end
 
 ## printfd ##
 
-@compat if Sys.isunix()
+if Sys.isunix()
     function printfd(n)
         open("/dev/null", "w") do io
             for i = 1:n
-                @compat Printf.@printf(io, "%d %d\n", i, i + 1)
+                Printf.@printf(io, "%d %d\n", i, i + 1)
             end
         end
     end

--- a/perfutil.jl
+++ b/perfutil.jl
@@ -1,10 +1,9 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-using Compat
-import Compat.Printf
-import Compat.Random
-import Compat.Statistics
-import Compat.Sys
+import Printf
+import Random
+import Statistics
+import Base.Sys
 
 const mintrials = 5
 const mintime = 2000.0
@@ -38,15 +37,15 @@ function submit_to_codespeed(vals,name,desc,unit,test_group,lessisbetter=true)
 
     csdata["benchmark"] = name
     csdata["description"] = desc
-    @compat csdata["result_value"] = Statistics.mean(vals)
-    @compat csdata["std_dev"] = Statistics.std(vals)
+    csdata["result_value"] = Statistics.mean(vals)
+    csdata["std_dev"] = Statistics.std(vals)
     csdata["min"] = minimum(vals)
     csdata["max"] = maximum(vals)
     csdata["units"] = unit
     csdata["units_title"] = test_group
     csdata["lessisbetter"] = lessisbetter
 
-    @compat println( "$name: $(Statistics.mean(vals))" )
+    println( "$name: $(Statistics.mean(vals))" )
     ret = post( "http://$codespeed_host/result/add/json/", Dict("json" => json([csdata])) )
     println( json([csdata]) )
     if ret.http_code != 200 && ret.http_code != 202
@@ -67,7 +66,7 @@ macro output_timings(t,name,desc,group)
         if codespeed
             submit_to_codespeed( $t, $name, $desc, "seconds", test_group )
         elseif print_output
-            @compat Printf.@printf "julia,%s,%f,%f,%f,%f\n" $name minimum($t) maximum($t) Statistics.mean($t) Statistics.std($t)
+            Printf.@printf "julia,%s,%f,%f,%f,%f\n" $name minimum($t) maximum($t) Statistics.mean($t) Statistics.std($t)
         end
         GC.gc()
     end
@@ -110,13 +109,13 @@ end
 
 function maxrss(name)
     # FIXME: call uv_getrusage instead here
-    @compat @static if (Sys.islinux())
+    @static if (Sys.islinux())
         rus = Vector{Int64}(uninitialized, div(144,8))
         fill!(rus, 0x0)
         res = ccall(:getrusage, Int32, (Int32, Ptr{Cvoid}), 0, rus)
         if res == 0
             mx = rus[5]/1024
-            @compat Printf.@printf "julia,%s.mem,%f,%f,%f,%f\n" name mx mx mx 0
+            Printf.@printf "julia,%s.mem,%f,%f,%f,%f\n" name mx mx mx 0
         end
     end
 end
@@ -128,5 +127,3 @@ if VERSION >= v"0.7.0"
 else
     srand(1776)
 end
-
-#@compat Random.seed!(1776)


### PR DESCRIPTION
removes usage of the Compat package

resolves CI errors

I believe this is an appropriate change as maintaining compat with older julia code for a benchmarks suite is not really in the best interest.

this PR also updates julia to latest stable (1.7.3) and python to latest release (3.10)