### PR TITLE
update `Makefile` to latest julia - add `LDFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ perf.h:
 	echo '#include "$(DSFMTDIR)/dSFMT.c"' >> $@
 
 bin/perf%: perf.c perf.h
-	$(CC) -std=c99 -O$* $< -o $@  -I$(DSFMTDIR) -lopenblas -L$(LIBMDIR) $(LIBM) $(CFLAGS) -lpthread
+	$(CC) -std=c99 -O$* $< -o $@  -I$(DSFMTDIR) $(LDFLAGS) -lopenblas -L$(LIBMDIR) $(LIBM) $(CFLAGS) -lpthread
 
 bin/fperf%: perf.f90
 	mkdir -p mods/$@ #Modules for each binary go in separate directories
-	$(FC) $(FFLAGS) -Jmods/$@ -O$* $< -o $@ -lopenblas -L$(LIBMDIR) $(LIBM) -lpthread
+	$(FC) $(FFLAGS) -Jmods/$@ -O$* $< -o $@ $(LDFLAGS) -lopenblas -L$(LIBMDIR) $(LIBM) -lpthread
 
 benchmarks/c.csv: \
 	benchmarks/c0.csv \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ endif
 .ONESHELL:
 
 include $(JULIAHOME)/Make.inc
-include $(JULIAHOME)/deps/Versions.make
 
 NODEJSBIN = node
 
@@ -53,7 +52,7 @@ export OMP_NUM_THREADS=1
 export GOTO_NUM_THREADS=1
 export OPENBLAS_NUM_THREADS=1
 
-perf.h: $(JULIAHOME)/deps/Versions.make
+perf.h:
 	echo '#include "cblas.h"' > $@
 	echo '#include "$(DSFMTDIR)/dSFMT.c"' >> $@
 


### PR DESCRIPTION
Fix https://github.com/JuliaLang/Microbenchmarks/issues/73.

Also add `LDFLAGS` in the `Makefile` for linking to a specific `openblas` library.